### PR TITLE
Doing more stuff

### DIFF
--- a/GoodminderLaravel/app/Api/V1/Controllers/GminderController.php
+++ b/GoodminderLaravel/app/Api/V1/Controllers/GminderController.php
@@ -35,6 +35,7 @@ class GminderController extends Controller
         $gminders = DB::table('gminders')
             ->leftJoin('prompts', 'gminders.prompt_id', '=', 'prompts.id')
             ->where('gminders.id', '=', $id)
+            ->where('gminders.user_id', '=', $currentUser)
             ->select('gminders.*', 'prompts.promptText')
             ->get();
 
@@ -45,10 +46,9 @@ class GminderController extends Controller
     {   
         $currentUser = Auth::guard()->user()->id;
 
-        $gminders = Gminder::where('user_id', $currentUser)->get();
-
         $gminders = DB::table('gminders')
             ->leftJoin('prompts', 'gminders.prompt_id', 'prompts.id')
+            ->where('gminders.user_id', '=', $currentUser)
             ->select('gminders.*', 'prompts.promptText')
             ->get();
 

--- a/GoodminderLaravel/app/Api/V1/Controllers/PromptCollectionController.php
+++ b/GoodminderLaravel/app/Api/V1/Controllers/PromptCollectionController.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Api\V1\Controllers;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Tymon\JWTAuth\JWTAuth;
+use App\Api\V1\Requests\LoginRequest;
+use Tymon\JWTAuth\Exceptions\JWTException;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Auth;
+use App\StoredPromptCollection;
+use App\PromptCollection;
+use App\Prompt;
+use Dingo\Api\Routing\Helpers;
+use Illuminate\Routing\Controller;
+use App\Api\V1\Requests\PromptRequest;
+
+class PromptCollectionController extends Controller
+{
+    use Helpers;
+   
+    /**
+     * Create a new AuthController instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('jwt.auth', []);
+    }
+
+    /* 
+    * Get all the promptTexts in a public prompt collection.
+    */
+    public function promptCollection($id)
+    {   
+        $promptCollection = PromptCollection::where([
+            ['id', '=', $id],
+            ['publicFlag', '=', 1]
+        ])->orWhere([
+            ['id', '=', $id],
+            ['creator_id', '=', Auth::guard()->user()->id]
+        ])->get();
+
+        if (empty(count($promptCollection))) {
+            return 'PromptCollection is either not public and/or is not owned by user.';
+        }
+
+        $prompts = \DB::table('prompts')
+            ->leftJoin('prompts_prompt_collections', 'prompts.id', '=', 'prompts_prompt_collections.prompt_id')
+            ->where('prompts_prompt_collections.prompt_collection_id', '=', $id)
+            ->get(['prompts.id','prompts.promptText']);
+        
+        return response()->json($prompts);
+    }
+
+    /* 
+    * Get public prompt collections, regardless of user.
+    */
+    public function promptCollections()
+    {   
+        return response()->json(PromptCollection::where('publicFlag', '=', 1)->get());
+    }
+
+    /* 
+    * Save a prompt collection as well as put it in the stored prompt collections for user.
+    */
+    public function store(PromptRequest $request)
+    {
+        $currentUser = Auth::guard()->user()->id;
+        
+        $promptCollection = new PromptCollection;
+        $promptCollection->creator_id = $currentUser;
+        $promptCollection->collection = $request->get('collection');
+        $promptCollection->description = $request->get('description');
+        if ($request->get('publicFlag') !== null) {
+            $promptCollection->publicFlag = $request->get('publicFlag');
+        }
+        
+        $promptCollection->save();
+
+        $storedPromptCollection = new StoredPromptCollection;
+        $storedPromptCollection->user_id = $currentUser;
+        $storedPromptCollection->displayFlag = 1;
+        $storedPromptCollection->prompt_collection_id = $promptCollection->id;
+
+        if ($storedPromptCollection->save()) {
+            return 'PromptCollection created and saved to StoredPromptCollection.';
+        } else {
+            return 'PromptCollection create and save to StoredPromptCollection failed.';
+        }
+    }
+
+    /* 
+     * Update user's own collection.
+     */
+    public function update(PromptRequest $request, $id)
+    { 
+        $promptCollection = PromptCollection::find($id);
+        $ownedByUser = $promptCollection->creator_id === Auth::guard()->user()->id;
+
+        if (!$ownedByUser) {
+            return 'PromptCollection is not owned by user. Update failed.';
+        }
+        
+        if ($request->get('collection') !== null) {
+            $promptCollection->collection = $request->get('collection');
+        }
+        if ($request->get('description') !== null) {
+            $promptCollection->description = $request->get('description');
+        }
+        if ($request->get('publicFlag') !== null) {
+            $promptCollection->publicFlag = $request->get('publicFlag');
+        }
+        
+        if ($promptCollection->save()) {
+            return 'Prompt collection updated.';
+        } else {
+           return 'Prompt collection update failed.';
+        }
+    }
+
+    /*
+    * Delete prompt collection as well as entry in stored prompt collection table.
+    */
+    public function destroy($id)
+    {
+        $promptCollection = PromptCollection::find($id);
+        $currentUser = Auth::guard()->user()->id; 
+        $ownedByUser = $currentUser === $promptCollection->creator_id;
+
+        if (!$ownedByUser) {
+            return 'Prompt collection is not owned by user; delete failed.';
+        }
+        
+        $storedPromptCollection = StoredPromptCollection::where('prompt_collection_id', '=', $id)
+            -> where('stored_prompt_collections.user_id', '=', $currentUser);
+
+        if ($promptCollection->delete() && $storedPromptCollection->delete()) {
+            return 'Prompt collection and associated stored prompt collection deleted.';
+        }
+        
+        return 'Prompt collection and associated stored prompt collection deletion failed.';
+    }
+}

--- a/GoodminderLaravel/app/Api/V1/Controllers/StoredPromptCollectionController.php
+++ b/GoodminderLaravel/app/Api/V1/Controllers/StoredPromptCollectionController.php
@@ -38,9 +38,9 @@ class StoredPromptCollectionController extends Controller
             ->leftJoin('stored_prompt_collections', 'prompt_collections.id', '=', 'stored_prompt_collections.prompt_collection_id')
             ->where('stored_prompt_collections.user_id', '=', $currentUser)
             ->get([
-                'prompt_collections.id', 'stored_prompt_collections.user_id','prompt_collections.creator_id', 
-                'prompt_collections.collection', 'prompt_collections.publicFlag', 
-                'prompt_collections.description'
+                'prompt_collections.id', 'stored_prompt_collections.prompt_collection_id', 'prompt_collections.creator_id', 'prompt_collections.collection', 'prompt_collections.description', 'stored_prompt_collections.displayFlag', 
+                'prompt_collections.publicFlag', 'stored_prompt_collections.created_at', 'stored_prompt_collections.updated_at'
+                
             ]);
 
         return response()->json($storedPromptCollections);

--- a/GoodminderLaravel/app/Api/V1/Controllers/UserController.php
+++ b/GoodminderLaravel/app/Api/V1/Controllers/UserController.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Tymon\JWTAuth\JWTAuth;
 use App\Http\Controllers\Controller;
 use App\Api\V1\Requests\LoginRequest;
+use App\Api\V1\Requests\UserRequest;
 use Tymon\JWTAuth\Exceptions\JWTException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Auth;
@@ -36,5 +37,28 @@ class UserController extends Controller
     public function nickname($id)
     {
         return response()->json(User::where('id', '=', $id)->get(['nickname']));
+    }
+
+    public function update(UserRequest $request, $id)
+    {
+        $user = User::find($id);
+        $userIsOwnedByUser = $user->id === Auth::guard()->user()->id;
+
+        if ($request->get('name') !== null) {
+            $user->name = $request->get('name');
+        }
+
+        if ($request->get('nickname') !== null) {
+            $user->nickname = $request->get('nickname');
+        }
+
+        if ($userIsOwnedByUser && $user->save()) {
+            return response()->json([
+                'name' => $user->name,
+                'nickname' => $user->nickname
+            ]);
+        } else {
+            return "User info update failed.";
+        }
     }
 }

--- a/GoodminderLaravel/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/GoodminderLaravel/database/migrations/2014_10_12_000000_create_users_table.php
@@ -16,7 +16,7 @@ class CreateUsersTable extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name')->nullable();
-            $table->string('nickname')->nullable();
+            $table->string('nickname')->unique();
             $table->string('email')->unique();
             $table->string('password');
             $table->string('status')->nullable();

--- a/GoodminderLaravel/routes/api.php
+++ b/GoodminderLaravel/routes/api.php
@@ -40,6 +40,12 @@ $api->version('v1', function (Router $api) {
         $api->get('users/{id}', 'App\\Api\\V1\\Controllers\\UserController@nickname');
         $api->put('users/{id}', 'App\\Api\\V1\\Controllers\\UserController@update');
 
+        $api->get('promptCollections', 'App\\Api\\V1\\Controllers\\promptCollectionController@promptCollections');
+        $api->get('promptCollections/{id}', 'App\\Api\\V1\\Controllers\\promptCollectionController@promptCollection');
+        $api->post('promptCollections', 'App\\Api\\V1\\Controllers\\promptCollectionController@store');
+        $api->put('promptCollections/{id}', 'App\\Api\\V1\\Controllers\\promptCollectionController@update');
+        $api->delete('promptCollections/{id}', 'App\\Api\\V1\\Controllers\\promptCollectionController@destroy');
+
         $api->get('storedPromptCollections', 'App\\Api\\V1\\Controllers\\StoredPromptCollectionController@storedPromptCollections');
         $api->post('storedPromptCollections', 'App\\Api\\V1\\Controllers\\StoredPromptCollectionController@store');
         $api->put('storedPromptCollections/{id}', 'App\\Api\\V1\\Controllers\\StoredPromptCollectionController@update');

--- a/GoodminderLaravel/routes/api.php
+++ b/GoodminderLaravel/routes/api.php
@@ -38,6 +38,7 @@ $api->version('v1', function (Router $api) {
         $api->get('prompts', 'App\\Api\\V1\\Controllers\\PromptController@userPrompts');
 
         $api->get('users/{id}', 'App\\Api\\V1\\Controllers\\UserController@nickname');
+        $api->put('users/{id}', 'App\\Api\\V1\\Controllers\\UserController@update');
 
         $api->get('storedPromptCollections', 'App\\Api\\V1\\Controllers\\StoredPromptCollectionController@storedPromptCollections');
         $api->post('storedPromptCollections', 'App\\Api\\V1\\Controllers\\StoredPromptCollectionController@store');


### PR DESCRIPTION
changes
- updated single gminder retrieval so it will only retrieve user's gminders
- updated user's gminder retrieval so it will only retrieve user's gminders
- only send user's prompts (not storedPromptCollections or anything else)
- fix bug to get prompts
- make nicknames required and ensure they are unique (need to rerun migration)
- add route to update name and nickname
- update single prompt, or create new one if being used by gminder
- add promptCollection routes